### PR TITLE
Implement layered 3D navigation

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -34,7 +34,8 @@
 </head>
 <body>
     <div id="canvas-container"></div>
-    <div class="overlay">Scroll or Swipe to Move | Tap Folders to Open</div>
+    <button id="backButton" style="position:absolute;top:20px;left:20px;z-index:1;">Back</button>
+    <div class="overlay">Use Arrow Keys or Click/Tap Folders</div>
 
     <!-- Import Map for Three.js -->
     <script type="importmap">

--- a/public_html/js/folderView.js
+++ b/public_html/js/folderView.js
@@ -1,0 +1,33 @@
+import * as THREE from 'three';
+import { siteTree } from './siteTree.js';
+
+export function createHierarchy(scene) {
+    const layerSpacing = 15;
+    const layers = [];
+
+    function addNodes(nodes, depth = 0) {
+        if (!layers[depth]) {
+            const g = new THREE.Group();
+            g.position.z = -depth * layerSpacing;
+            scene.add(g);
+            layers[depth] = g;
+        }
+        nodes.forEach((node, index) => {
+            const size = node.type === 'folder' ? 3 : 2;
+            const color = node.type === 'folder' ? 0x0077ff : 0x777777;
+            const geometry = new THREE.BoxGeometry(size, size, size);
+            const material = new THREE.MeshStandardMaterial({ color });
+            const mesh = new THREE.Mesh(geometry, material);
+            const offset = index - (nodes.length - 1) / 2;
+            mesh.position.x = offset * (size + 1.5);
+            mesh.userData.node = node;
+            layers[depth].add(mesh);
+            if (node.children) {
+                addNodes(node.children, depth + 1);
+            }
+        });
+    }
+
+    addNodes(siteTree.children, 0);
+    return layers;
+}

--- a/public_html/js/layerControls.js
+++ b/public_html/js/layerControls.js
@@ -1,0 +1,45 @@
+import * as THREE from 'three';
+
+export function setupLayerControls(camera, layers) {
+    let currentDepth = 0;
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+
+    function showLayer(depth) {
+        if (depth < 0 || depth >= layers.length) return;
+        camera.position.z = layers[depth].position.z + 10;
+        currentDepth = depth;
+    }
+
+    window.addEventListener('pointerdown', (event) => {
+        mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+        mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+        raycaster.setFromCamera(mouse, camera);
+        const intersects = raycaster.intersectObjects(layers[currentDepth].children);
+        if (intersects.length > 0) {
+            const node = intersects[0].object.userData.node;
+            if (node.children) {
+                showLayer(currentDepth + 1);
+            } else if (node.url) {
+                window.location.href = node.url;
+            }
+        }
+    });
+
+    const backBtn = document.getElementById('backButton');
+    if (backBtn) {
+        backBtn.addEventListener('click', () => {
+            if (currentDepth > 0) showLayer(currentDepth - 1);
+        });
+    }
+
+    window.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowUp') {
+            showLayer(currentDepth + 1);
+        } else if (e.key === 'ArrowDown') {
+            showLayer(currentDepth - 1);
+        }
+    });
+
+    showLayer(0);
+}

--- a/public_html/js/main.js
+++ b/public_html/js/main.js
@@ -1,36 +1,25 @@
 import { createScene, createCamera, createRenderer } from './scene.js';
 import { addLighting } from './lighting.js';
-import { createRoad } from './road.js';
 import { createStarfield } from './stars.js';
-import { setupControls } from './controls.js';
-import { createPages } from './pages.js';
-import { createLines } from './lines.js'; // Import lines
+import { createHierarchy } from './folderView.js';
+import { setupLayerControls } from './layerControls.js';
 
-// Create the scene, camera, and renderer
 const scene = createScene();
 const camera = createCamera();
 const renderer = createRenderer();
 
-// Add elements
 addLighting(scene);
-//createRoad(scene);
-setupControls(camera);
 const animateStars = createStarfield(scene);
 
-// Generate Boxes & Draw 90° Bent Connection Lines
-createPages(scene).then((pageBoxes) => {
-    createLines(scene, pageBoxes); // Connect related pages
-    setupControls(camera, pageBoxes); // Make them clickable
-});
+const layers = createHierarchy(scene);
+setupLayerControls(camera, layers);
 
-// Handle Resizing
-window.addEventListener("resize", () => {
+window.addEventListener('resize', () => {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
     renderer.setSize(window.innerWidth, window.innerHeight);
 });
 
-// Animation Loop
 function animate() {
     requestAnimationFrame(animate);
     animateStars();

--- a/public_html/js/siteTree.js
+++ b/public_html/js/siteTree.js
@@ -1,0 +1,16 @@
+export const siteTree = {
+    name: 'root',
+    type: 'folder',
+    children: [
+        { name: 'Fake', type: 'file', url: './fake.html' },
+        { name: 'Mutual Learning', type: 'file', url: './mutuallearning.html' },
+        { name: 'This Site', type: 'file', url: './thissite.html' },
+        {
+            name: 'Isaac',
+            type: 'folder',
+            children: [
+                { name: 'Isaac Main', type: 'file', url: './isaac/public_html/index.html' }
+            ]
+        }
+    ]
+};

--- a/public_html/normal/index.html
+++ b/public_html/normal/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Normal Navigation</title>
+</head>
+<body>
+    <h1>Normal Navigation</h1>
+    <ul>
+        <li><a href="../fake.html">Fake</a></li>
+        <li><a href="../mutuallearning.html">Mutual Learning</a></li>
+        <li><a href="../thissite.html">This Site</a></li>
+        <li><a href="../isaac/public_html/index.html">Isaac</a></li>
+    </ul>
+    <p><a href="../index.html">3D Version</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add back button to 3D page and new overlay text
- provide normal HTML navigation under `normal/`
- implement siteTree and functions to create layered folder view
- add controls for navigating layers and visiting pages
- update main script to use new modules

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685338b1784883319d985eddf4ebcfa8